### PR TITLE
Load samples into buffers

### DIFF
--- a/barcode.lua
+++ b/barcode.lua
@@ -92,7 +92,10 @@ function init()
     params:set("save_name",filename)
   end)
   params:add_text('save_message',">","")
-
+  params:add_file('import1', 'buffer 1 sample')
+  params:set_action('import1', function(f) import(f, 1) end)
+  params:add_file('import2', 'buffer 2 sample')
+  params:set_action('import2', function(f) import(f, 2) end)
   params:add_option("quantize","lfo bpm sync.",{"off","on"},1)
   params:set_action("quantize",update_parameters)
   params:add_option("recording","recording",{"off","on"},1)
@@ -625,6 +628,15 @@ function toggle_recording(x)
   end
 end
 
+function import(f, ch)
+  if util.file_exists(f) then
+    softcut.buffer_clear_channel(ch)
+    softcut.buffer_read_mono(f,0,0,60,1,ch)
+    local _, samples, rate = audio.file_info(f)
+    local duration = math.min((samples/rate), 60)
+    state.buffer_size[ch]=duration
+  end
+end
 
 --
 -- saving and loading


### PR DESCRIPTION
While using barcode, I found myself wanting to load samples from the norns filesystem (in particular the contents of the internal "tape") easily. In this PR I've added two parameter menu entries to load a sample into either of the two buffers. 

I've decided to use the parameter menu for this in a similar way to how `cheat codes` works. I also considered a parameter toggle to switch recording "mode" from either input or file, and then modifying the behaviour of K3. But I couldn't find an easy way to launch a file picker from a key press. 

I haven't currently added any error checking on the loaded file (such as its presence, or length). 

Would you be interested in incorporating this PR @schollz? I'm happy to rework it if it might be useful - this is my first bit of norns scripting so I may not be using best practices! 

