### PR TITLE
Allow buffer to be loaded from a file

### DIFF
--- a/barcode.lua
+++ b/barcode.lua
@@ -426,6 +426,7 @@ end
 
 function fileselect_callback(f)
    if util.file_exists(f) then
+      softcut.buffer_clear_channel(state.buffer)
       softcut.buffer_read_mono(f,0,0,-1,1,state.buffer)
       local _, samples, rate = audio.file_info(f)
       state.buffer_size[state.buffer]=(samples/rate)


### PR DESCRIPTION
This PR adds a parameter "audio source". When set to "audio in" the current behaviour is unchanged (K3 records from the norns audio input into the currently selected buffer).

When set to "file", the behaviour of K3 is changed. K3 now opens a file select and the buffer is set to the contents of the file (as determined by `softcut.buffer_read_mono`). I've used `audio.file_info` to determine the file length and set `state.buffer_size` appropriately.

The additional state variable `selecting_file` ensures that the screen redraw routine called in the lfo metro returns early while the user is selecting a file.

I think the user interface for this is better than the one I proposed in https://github.com/schollz/barcode/pull/13 because it seems more likely that a user's setup would be either "file" or "audio in" so this allows you to set it once per session and change buffers more easily. 